### PR TITLE
Add missing List import

### DIFF
--- a/xview2_metrics.py
+++ b/xview2_metrics.py
@@ -21,7 +21,7 @@ import pandas as pd
 from multiprocessing import Pool, cpu_count
 from pathlib import Path
 from PIL import Image
-from typing import Union
+from typing import Union, List
 
 class PathHandler:
     def __init__(self, pred_dir:Path, targ_dir:Path, img_id:str, test_hold:str):


### PR DESCRIPTION
[This function definition](https://github.com/DIUx-xView/xview2-scoring/blob/e500cf760215a55bc802be8e52b8e8120979160f/xview2_metrics.py#L73) uses the `List` type annotation however it is not imported from the `typing` module.  This does not seem to break anything when the file is run as a script, but it does throw an exception when the module is imported into another module.